### PR TITLE
update manual to clarify how abstain votes affect approval threshold

### DIFF
--- a/manual.md
+++ b/manual.md
@@ -62,7 +62,7 @@ In the third week, all delegates (including OP token holders who have self-deleg
 A Token House governance proposal is **approved** if it satisfies the following minimum vote thresholds:
 
 - **Quorum:** The minimum number of total OP votes required to be cast in connection with a proposal. Here, a quorum is measured as *a % of the total votable OP supply*. “Votable supply” is the total amount of OP that has been delegated, and therefore can participate in voting. The total votable OP supply will be determined based on a reasonable estimate provided by the Optimism Foundation prior to each Voting Cycle. OP votable supply will be included in each Voting Roundup Thread. 
-- **Approval threshold:** The minimum number of OP votes required to be cast in favor of approving a proposal. The approval threshold for each proposal is measured as *% of votes cast to approve relative to the total number of votes cast in connection with a proposal*.
+- **Approval threshold:** The minimum number of OP votes required to be cast in favor of approving a proposal. The approval threshold for each proposal is measured as *minimum % of votes cast to approve reletave to total non-abstaining votes cast*.
 
 **A snapshot to determine voting power** for each delegate will be taken at the commencement of a given voting period, and voting will be hosted on the [Optimism Collective Snapshot page](https://snapshot.org/#/opcollective.eth).
 


### PR DESCRIPTION
On 6 July, a delegate asked about how voting "abstain" on a proposal affects the overall approval threshold. 

The Optimism team [clarified in Discord](https://discord.com/channels/667044843901681675/989611992295813241/994267466471575572) that "abstain" votes count towards Quorum (total % of votable OP required to pass a vote) but do NOT count towards the Approval Threshold. Approval is calculated as "votes cast to approve relative to total non-abstaining votes cast." However, the Operating Manual was never updated to include this change. 

This PR adds the language to the Operating Manual that was shared with the community in Discord. 

<img width=700px src=https://user-images.githubusercontent.com/1016190/196564218-9b9c0d0d-cd10-4899-aa62-5dbb8331ec5c.png>





