### PR TITLE
Typo fix  Developer Advisory Board Charter v1.1.md

### DIFF
--- a/Developer Advisory Board Charter v1.1.md
+++ b/Developer Advisory Board Charter v1.1.md
@@ -53,7 +53,7 @@ The members of these subcommittees exist with the mandate of ensuring that the b
 
 In addition to the subcommittee responsibilities, there are two additional roles that individual Developer Advisory Board members will take on. These roles will be voted on internally by the Developer Advisory Board and include: Ops Lead and Mission Scouts.
 
-- The Ops Lead (1 member) is responsibile for managing the operations of the board, including:
+- The Ops Lead (1 member) is responsible for managing the operations of the board, including:
     - (a) improving the IOPs
     - (b) scheduling meetings
     - (c) interfacing with other Councils


### PR DESCRIPTION
## Pull Request Title: Typo Fix in `Developer Advisory Board Charter v1.1.md`

### Description:
This pull request corrects a typo in the `Developer Advisory Board Charter v1.1.md` file. The word **"responsibile"** has been corrected to **"responsible"**.

### Changes:
- Corrected typo from **"responsibile"** to **"responsible"** in the file.

### Why this change is necessary:
- The typo was affecting the clarity and professionalism of the document.
- This update ensures that the document is grammatically correct, especially in a formal context like the Developer Advisory Board's guidelines.

### How to test:
- Review the `Developer Advisory Board Charter v1.1.md` to confirm the correction is made.
- This is a documentation change, so no functional testing is needed.

### Additional Information:
- This change does not affect any code or functionality, only the text within the manual.
